### PR TITLE
Update PHPUnit, increase PHPStan scrutiny, improve tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        php-version: [ 8.1, 8.2, 8.3, 8.4 ]
+        php-version: [ 8.2, 8.3, 8.4 ]
 
     steps:
       - name: Checkout Repository

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ coverage-report
 coverage.xml
 vendor
 .phpunit.result.cache
+.phpunit.cache
+.idea

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,11 @@
     "php": "^8.0"
   },
   "require-dev": {
-    "phpunit/php-code-coverage": "^2.2.4 || ^9.0.0",
-    "phpunit/phpunit": "^9.0",
-    "phpstan/phpstan": "^2.0"
+    "phpunit/php-code-coverage": "^11.0.0",
+    "phpunit/phpunit": "^11.0",
+    "phpstan/phpstan": "^2.0",
+    "phpstan/extension-installer": "^1.4",
+    "phpstan/phpstan-strict-rules": "^2.0"
   },
   "autoload": {
     "psr-4": {
@@ -35,6 +37,11 @@
   "autoload-dev": {
     "psr-4": {
       "mishagp\\OCRmyPDF\\Tests\\": "tests/"
+    }
+  },
+  "config": {
+    "allow-plugins": {
+      "phpstan/extension-installer": true
     }
   }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,5 +3,4 @@ parameters:
         - src
         - tests
 
-    # The level 9 is the highest level
-    level: 9
+    level: 10

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,19 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false"
-         stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-    </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
+         executionOrder="depends,defects"
+         shortenArraysForExportThreshold="10"
+         requireCoverageMetadata="true"
+         beStrictAboutCoverageMetadata="true"
+         displayDetailsOnPhpunitDeprecations="true"
+         failOnPhpunitDeprecation="true"
+         failOnRisky="true"
+         failOnWarning="true">
     <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit</directory>
-        </testsuite>
-        <testsuite name="E2E">
-            <directory suffix="Test.php">./tests/E2E</directory>
+        <testsuite name="default">
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
+
+    <source ignoreIndirectDeprecations="true" restrictNotices="true" restrictWarnings="true">
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/Command.php
+++ b/src/Command.php
@@ -38,7 +38,7 @@ class Command
             if (file_exists($file) && filesize($file) > 0) return true;
         }
 
-        if (!$command->useFileAsOutput && $stdout) {
+        if (!$command->useFileAsOutput && $stdout === '') {
             return true;
         }
 
@@ -70,7 +70,7 @@ class Command
 
         $cmd[] = self::escape($this->executable);
 
-        if ($this->threadLimit) $cmd[] = "--jobs=$this->threadLimit";
+        if ($this->threadLimit !== null) $cmd[] = "--jobs=$this->threadLimit";
 
         foreach ($this->parameters as $key => $value) {
             if ($value !== true) {
@@ -99,7 +99,7 @@ class Command
      */
     public function getOutputPDFPath(): string
     {
-        if (!$this->outputPDFPath) {
+        if ($this->outputPDFPath === null) {
             $tempPath = tempnam($this->getTempDir(), 'ocr_');
             if ($tempPath === false) {
                 throw new NoWritePermissionsException("Cannot create temporary file in {$this->getTempDir()}");
@@ -114,7 +114,7 @@ class Command
 
     public function getTempDir(): string
     {
-        return $this->tempDir ?: sys_get_temp_dir();
+        return $this->tempDir !== null ? $this->tempDir : sys_get_temp_dir();
     }
 
     public function getOCRmyPDFVersion(): string
@@ -125,7 +125,7 @@ class Command
 
     public static function escape(string $str): string
     {
-        $charlist = strtoupper(substr(PHP_OS, 0, 3)) == 'WIN' ? '$"`' : '$"\\`';
+        $charlist = strtoupper(substr(PHP_OS, 0, 3)) === 'WIN' ? '$"`' : '$"\\`';
         return '"' . addcslashes($str, $charlist) . '"';
     }
 }

--- a/src/OCRmyPDF.php
+++ b/src/OCRmyPDF.php
@@ -15,7 +15,7 @@ class OCRmyPDF
      */
     public function __construct(?string $inputFile = null, ?Command $command = null)
     {
-        $this->command = $command !== null ? $command : new Command();
+        $this->command = $command ?? new Command();
         $this->setInputFile("$inputFile");
     }
 

--- a/src/OCRmyPDF.php
+++ b/src/OCRmyPDF.php
@@ -15,7 +15,7 @@ class OCRmyPDF
      */
     public function __construct(?string $inputFile = null, ?Command $command = null)
     {
-        $this->command = $command ?: new Command();
+        $this->command = $command !== null ? $command : new Command();
         $this->setInputFile("$inputFile");
     }
 
@@ -60,7 +60,7 @@ class OCRmyPDF
             : 'type ' . Command::escape($executablePath) . ' > /dev/null 2>&1';
         system($cmd, $exitCode);
 
-        if ($exitCode == 0) return;
+        if ($exitCode === 0) return;
 
         $currentPath = getenv('PATH');
         $msg = [];
@@ -142,6 +142,7 @@ class OCRmyPDF
      */
     public function setInputFile(string $inputFile): OCRmyPDF
     {
+        $this->command->useFileAsInput = true;
         $this->command->inputFilePath = $inputFile;
         return $this;
     }
@@ -190,7 +191,7 @@ class OCRmyPDF
      */
     public function setOutputPDFPath(string|null $outputPDFPath): self
     {
-        if ($outputPDFPath == null) {
+        if ($outputPDFPath === null) {
             $this->command->useFileAsOutput = false;
         } else {
             $this->command->useFileAsOutput = true;

--- a/src/Process.php
+++ b/src/Process.php
@@ -33,12 +33,12 @@ class Process
             ["pipe", "w"]
         ];
         $this->handle = proc_open(
-            $commandString,
-            $streamDescriptors,
-            $pipes,
-            NULL,
-            NULL,
-            ["bypass_shell" => true]
+            command: $commandString,
+            descriptor_spec: $streamDescriptors,
+            pipes: $pipes,
+            cwd: NULL,
+            env_vars: NULL,
+            options: ["bypass_shell" => true]
         );
 
         /** @var array<resource> $pipes */

--- a/src/Process.php
+++ b/src/Process.php
@@ -9,17 +9,17 @@ class Process
     /**
      * @var ?resource $stdin
      */
-    private mixed $stdin;
+    private $stdin;
 
     /**
      * @var ?resource $stdout
      */
-    private mixed $stdout;
+    private $stdout;
 
     /**
      * @var ?resource $stderr
      */
-    private mixed $stderr;
+    private $stderr;
     private mixed $handle;
 
     /**
@@ -32,14 +32,35 @@ class Process
             ["pipe", "w"],
             ["pipe", "w"]
         ];
-        $this->handle = proc_open($commandString, $streamDescriptors, $pipes, NULL, NULL, ["bypass_shell" => true]);
-        list($this->stdin, $this->stdout, $this->stderr) = $pipes;
+        $this->handle = proc_open(
+            $commandString,
+            $streamDescriptors,
+            $pipes,
+            NULL,
+            NULL,
+            ["bypass_shell" => true]
+        );
+
+        /** @var array<resource> $pipes */
+        if (isset($pipes[0])) {
+            $this->stdin = $pipes[0];
+        }
+        if (isset($pipes[1])) {
+            $this->stdout = $pipes[1];
+        }
+        if (isset($pipes[2])) {
+            $this->stderr = $pipes[2];
+        }
 
         self::checkProcessCreation($this->handle, $commandString);
 
-        //This can avoid deadlock on some cases (when stderr buffer is filled up before writing to stdout and vice-versa)
-        stream_set_blocking($this->stdout, false);
-        stream_set_blocking($this->stderr, false);
+        //This can avoid deadlock on some cases (when stderr buffer is filled up before writing to stdout and vice versa)
+        if (is_resource($this->stdout)) {
+            stream_set_blocking($this->stdout, false);
+        }
+        if (is_resource($this->stderr)) {
+            stream_set_blocking($this->stderr, false);
+        }
     }
 
     /**
@@ -50,7 +71,7 @@ class Process
         if (is_resource($processHandle) === true) {
             return;
         }
-
+        $msg = [];
         $msg[] = 'Error: The command could not be launched.';
         $msg[] = '';
         $msg[] = 'Generated command:';
@@ -69,7 +90,12 @@ class Process
         $total = 0;
         do {
             $res = fwrite($this->stdin, substr($data, $total));
-        } while ($res && $total += $res < $dataLength);
+            if ($res === false) {
+                break;
+            }
+
+            $total += $res;
+        } while ($total < $dataLength);
         return $total === $dataLength;
     }
 

--- a/tests/E2E/OCRmyPDFAcceptsStdinInputTest.php
+++ b/tests/E2E/OCRmyPDFAcceptsStdinInputTest.php
@@ -4,12 +4,22 @@
 namespace mishagp\OCRmyPDF\Tests\E2E;
 
 
+use mishagp\OCRmyPDF\Command;
 use mishagp\OCRmyPDF\NoWritePermissionsException;
 use mishagp\OCRmyPDF\OCRmyPDF;
 use mishagp\OCRmyPDF\OCRmyPDFException;
+use mishagp\OCRmyPDF\Process;
+use mishagp\OCRmyPDF\Tests\Helpers;
 use mishagp\OCRmyPDF\UnsuccessfulCommandException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use function PHPUnit\Framework\assertFileExists;
+use function PHPUnit\Framework\assertFileIsReadable;
+use function PHPUnit\Framework\assertFileIsWritable;
 
+#[CoversClass(OCRmyPDF::class)]
+#[CoversClass(Command::class)]
+#[CoversClass(Process::class)]
 class OCRmyPDFAcceptsStdinInputTest extends TestCase
 {
     /**
@@ -23,9 +33,9 @@ class OCRmyPDFAcceptsStdinInputTest extends TestCase
         $instance = new OCRmyPDF();
         $instance->setInputData((string)file_get_contents($inputFile), (int)filesize($inputFile));
         $outputPath = $instance->run();
-        $this->assertFileExists($outputPath);
-        $this->assertFileIsReadable($outputPath);
-        $this->assertFileIsWritable($outputPath);
-        echo "Output: $outputPath";
+        assertFileExists($outputPath);
+        assertFileIsReadable($outputPath);
+        assertFileIsWritable($outputPath);
+        Helpers::echoOutputPathWithTestContext($outputPath);
     }
 }

--- a/tests/E2E/OCRmyPDFGeneratesOutputFileTest.php
+++ b/tests/E2E/OCRmyPDFGeneratesOutputFileTest.php
@@ -2,12 +2,22 @@
 
 namespace mishagp\OCRmyPDF\Tests\E2E;
 
+use mishagp\OCRmyPDF\Command;
 use mishagp\OCRmyPDF\NoWritePermissionsException;
 use mishagp\OCRmyPDF\OCRmyPDF;
 use mishagp\OCRmyPDF\OCRmyPDFException;
+use mishagp\OCRmyPDF\Process;
+use mishagp\OCRmyPDF\Tests\Helpers;
 use mishagp\OCRmyPDF\UnsuccessfulCommandException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use function PHPUnit\Framework\assertFileExists;
+use function PHPUnit\Framework\assertFileIsReadable;
+use function PHPUnit\Framework\assertFileIsWritable;
 
+#[CoversClass(OCRmyPDF::class)]
+#[CoversClass(Command::class)]
+#[CoversClass(Process::class)]
 class OCRmyPDFGeneratesOutputFileTest extends TestCase
 {
     /**
@@ -20,10 +30,10 @@ class OCRmyPDFGeneratesOutputFileTest extends TestCase
         $inputFile = __DIR__ . DIRECTORY_SEPARATOR . "examples" . DIRECTORY_SEPARATOR . "en_US_doc1.pdf";
         $instance = new OCRmyPDF($inputFile);
         $outputPath = $instance->run();
-        $this->assertFileExists($outputPath);
-        $this->assertFileIsReadable($outputPath);
-        $this->assertFileIsWritable($outputPath);
-        echo "Output: $outputPath";
+        assertFileExists($outputPath);
+        assertFileIsReadable($outputPath);
+        assertFileIsWritable($outputPath);
+        Helpers::echoOutputPathWithTestContext($outputPath);
     }
 
     /**
@@ -36,10 +46,10 @@ class OCRmyPDFGeneratesOutputFileTest extends TestCase
         $inputFile = __DIR__ . DIRECTORY_SEPARATOR . "examples" . DIRECTORY_SEPARATOR . "en_US_doc2.pdf";
         $instance = new OCRmyPDF($inputFile);
         $outputPath = $instance->run();
-        $this->assertFileExists($outputPath);
-        $this->assertFileIsReadable($outputPath);
-        $this->assertFileIsWritable($outputPath);
-        echo "Output: $outputPath";
+        assertFileExists($outputPath);
+        assertFileIsReadable($outputPath);
+        assertFileIsWritable($outputPath);
+        Helpers::echoOutputPathWithTestContext($outputPath);
     }
 
     /**
@@ -52,10 +62,10 @@ class OCRmyPDFGeneratesOutputFileTest extends TestCase
         $inputFile = __DIR__ . DIRECTORY_SEPARATOR . "examples" . DIRECTORY_SEPARATOR . "en_US_doc3.pdf";
         $instance = new OCRmyPDF($inputFile);
         $outputPath = $instance->run();
-        $this->assertFileExists($outputPath);
-        $this->assertFileIsReadable($outputPath);
-        $this->assertFileIsWritable($outputPath);
-        echo "Output: $outputPath";
+        assertFileExists($outputPath);
+        assertFileIsReadable($outputPath);
+        assertFileIsWritable($outputPath);
+        Helpers::echoOutputPathWithTestContext($outputPath);
     }
 
     /**
@@ -68,10 +78,10 @@ class OCRmyPDFGeneratesOutputFileTest extends TestCase
         $inputFile = __DIR__ . DIRECTORY_SEPARATOR . "examples" . DIRECTORY_SEPARATOR . "en_US_img1.png";
         $instance = new OCRmyPDF($inputFile);
         $outputPath = $instance->run();
-        $this->assertFileExists($outputPath);
-        $this->assertFileIsReadable($outputPath);
-        $this->assertFileIsWritable($outputPath);
-        echo "Output: $outputPath";
+        assertFileExists($outputPath);
+        assertFileIsReadable($outputPath);
+        assertFileIsWritable($outputPath);
+        Helpers::echoOutputPathWithTestContext($outputPath);
     }
 
     /**
@@ -85,9 +95,9 @@ class OCRmyPDFGeneratesOutputFileTest extends TestCase
         $instance = new OCRmyPDF($inputFile);
         $instance->setOutputPDFPath(sys_get_temp_dir() . DIRECTORY_SEPARATOR . basename((string)tempnam(sys_get_temp_dir(), 'ocr_')) . ".pdf");
         $outputPath = $instance->run();
-        $this->assertFileExists($outputPath);
-        $this->assertFileIsReadable($outputPath);
-        $this->assertFileIsWritable($outputPath);
-        echo "Output: $outputPath";
+        assertFileExists($outputPath);
+        assertFileIsReadable($outputPath);
+        assertFileIsWritable($outputPath);
+        Helpers::echoOutputPathWithTestContext($outputPath);
     }
 }

--- a/tests/E2E/OCRmyPDFGeneratesOutputStdoutTest.php
+++ b/tests/E2E/OCRmyPDFGeneratesOutputStdoutTest.php
@@ -4,12 +4,19 @@
 namespace mishagp\OCRmyPDF\Tests\E2E;
 
 
+use mishagp\OCRmyPDF\Command;
 use mishagp\OCRmyPDF\NoWritePermissionsException;
 use mishagp\OCRmyPDF\OCRmyPDF;
 use mishagp\OCRmyPDF\OCRmyPDFException;
+use mishagp\OCRmyPDF\Process;
 use mishagp\OCRmyPDF\UnsuccessfulCommandException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use function PHPUnit\Framework\assertTrue;
 
+#[CoversClass(OCRmyPDF::class)]
+#[CoversClass(Command::class)]
+#[CoversClass(Process::class)]
 class OCRmyPDFGeneratesOutputStdoutTest extends TestCase
 {
     /**
@@ -24,6 +31,9 @@ class OCRmyPDFGeneratesOutputStdoutTest extends TestCase
         $instance->setInputFile($inputFile);
         $instance->setOutputPDFPath(null);
         $stdOut = $instance->run();
-        $this->assertStringContainsString("<xmp:CreatorTool>ocrmypdf", $stdOut);
+        assertTrue(
+            str_contains($stdOut, "<xmp:CreatorTool>OCRmyPDF")
+            || str_contains($stdOut, "<xmp:CreatorTool>ocrmypdf")
+        );
     }
 }

--- a/tests/E2E/OCRmyPDFParsesParametersTest.php
+++ b/tests/E2E/OCRmyPDFParsesParametersTest.php
@@ -3,11 +3,21 @@
 namespace mishagp\OCRmyPDF\Tests\E2E;
 
 use InvalidArgumentException;
+use mishagp\OCRmyPDF\Command;
 use mishagp\OCRmyPDF\OCRmyPDF;
 use mishagp\OCRmyPDF\OCRmyPDFException;
+use mishagp\OCRmyPDF\Process;
+use mishagp\OCRmyPDF\Tests\Helpers;
 use mishagp\OCRmyPDF\UnsuccessfulCommandException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use function PHPUnit\Framework\assertFileExists;
+use function PHPUnit\Framework\assertFileIsReadable;
+use function PHPUnit\Framework\assertFileIsWritable;
 
+#[CoversClass(OCRmyPDF::class)]
+#[CoversClass(Command::class)]
+#[CoversClass(Process::class)]
 class OCRmyPDFParsesParametersTest extends TestCase
 {
     /**
@@ -27,10 +37,10 @@ class OCRmyPDFParsesParametersTest extends TestCase
             ->setParam('--title', "Lorem Ipsum");
 
         $outputPath = $instance->run();
-        $this->assertFileExists($outputPath);
-        $this->assertFileIsReadable($outputPath);
-        $this->assertFileIsWritable($outputPath);
-        echo "Output: $outputPath";
+        assertFileExists($outputPath);
+        assertFileIsReadable($outputPath);
+        assertFileIsWritable($outputPath);
+        Helpers::echoOutputPathWithTestContext($outputPath);
     }
 
     /**
@@ -50,10 +60,10 @@ class OCRmyPDFParsesParametersTest extends TestCase
             ->setParam('--pages', ['1-2', '4']);
 
         $outputPath = $instance->run();
-        $this->assertFileExists($outputPath);
-        $this->assertFileIsReadable($outputPath);
-        $this->assertFileIsWritable($outputPath);
-        echo "Output: $outputPath";
+        assertFileExists($outputPath);
+        assertFileIsReadable($outputPath);
+        assertFileIsWritable($outputPath);
+        Helpers::echoOutputPathWithTestContext($outputPath);
     }
 
     /**

--- a/tests/E2E/OCRmyPDFThrowsExceptionsTest.php
+++ b/tests/E2E/OCRmyPDFThrowsExceptionsTest.php
@@ -4,14 +4,20 @@
 namespace mishagp\OCRmyPDF\Tests\E2E;
 
 
+use mishagp\OCRmyPDF\Command;
 use mishagp\OCRmyPDF\FileNotFoundException;
 use mishagp\OCRmyPDF\NoWritePermissionsException;
 use mishagp\OCRmyPDF\OCRmyPDF;
 use mishagp\OCRmyPDF\OCRmyPDFException;
 use mishagp\OCRmyPDF\OCRmyPDFNotFoundException;
+use mishagp\OCRmyPDF\Process;
 use mishagp\OCRmyPDF\UnsuccessfulCommandException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(OCRmyPDF::class)]
+#[CoversClass(Command::class)]
+#[CoversClass(Process::class)]
 class OCRmyPDFThrowsExceptionsTest extends TestCase
 {
     /**

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace mishagp\OCRmyPDF\Tests;
+class Helpers
+{
+    /**
+     * Outputs the provided path along with the name of the calling test method,
+     * if identifiable from the backtrace.
+     */
+    public static function echoOutputPathWithTestContext(string $outputPath): void
+    {
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+        $callingTestMethod = $backtrace[1]['function'] ?? 'unknown_method';
+        echo "Output from $callingTestMethod: $outputPath" . PHP_EOL;
+    }
+
+}

--- a/tests/Unit/CommandTest.php
+++ b/tests/Unit/CommandTest.php
@@ -3,26 +3,32 @@
 namespace mishagp\OCRmyPDF\Tests\Unit;
 
 use mishagp\OCRmyPDF\Command;
+use mishagp\OCRmyPDF\OCRmyPDF;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use function PHPUnit\Framework\assertEquals;
+use function PHPUnit\Framework\assertNotEmpty;
 
+#[CoversClass(OCRmyPDF::class)]
+#[CoversClass(Command::class)]
 class CommandTest extends TestCase
 {
     public function testGetOCRmyPDFVersion(): void
     {
         $version = (new Command())->getOCRmyPDFVersion();
-        $this->assertNotEmpty($version);
+        assertNotEmpty($version);
     }
 
     public function testGetTempDirDefaultTempDirectory(): void
     {
         $command = new Command();
-        $this->assertEquals(sys_get_temp_dir(), $command->getTempDir());
+        assertEquals(sys_get_temp_dir(), $command->getTempDir());
     }
 
     public function testGetTempDirCustomTempDirectory(): void
     {
         $customTempDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . rand(100000, 999999);
         $command = new Command(null, null, $customTempDir);
-        $this->assertEquals($customTempDir, $command->getTempDir());
+        assertEquals($customTempDir, $command->getTempDir());
     }
 }

--- a/tests/Unit/OCRmyPDFTest.php
+++ b/tests/Unit/OCRmyPDFTest.php
@@ -2,22 +2,27 @@
 
 namespace mishagp\OCRmyPDF\Tests\Unit;
 
+use mishagp\OCRmyPDF\Command;
 use mishagp\OCRmyPDF\FileNotFoundException;
 use mishagp\OCRmyPDF\NoWritePermissionsException;
 use mishagp\OCRmyPDF\OCRmyPDF;
 use mishagp\OCRmyPDF\OCRmyPDFNotFoundException;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use function PHPUnit\Framework\assertInstanceOf;
 
+#[CoversClass(OCRmyPDF::class)]
+#[CoversClass(Command::class)]
 class OCRmyPDFTest extends TestCase
 {
-
     /**
      * @throws NoWritePermissionsException
      */
     public function testCheckWritePermissions(): void
     {
-        if (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') {
-            $this->markTestSkipped('OCRmyPDFTest::testCheckWritePermissions unimplemented on Windows-based platforms, skipping.');
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            Assert::markTestSkipped('OCRmyPDFTest::testCheckWritePermissions unimplemented on Windows-based platforms, skipping.');
         }
         $this->expectException(NoWritePermissionsException::class);
         OCRmyPDF::checkWritePermissions("/dev/null");
@@ -35,6 +40,6 @@ class OCRmyPDFTest extends TestCase
     public function testSetExecutable(): void
     {
         $instance = new OCRmyPDF();
-        $this->assertInstanceOf(OCRmyPDF::class, $instance->setExecutable("ocrmypdf"));
+        assertInstanceOf(OCRmyPDF::class, $instance->setExecutable("ocrmypdf"));
     }
 }

--- a/tests/Unit/ProcessTest.php
+++ b/tests/Unit/ProcessTest.php
@@ -5,9 +5,13 @@ namespace mishagp\OCRmyPDF\Tests\Unit;
 use InvalidArgumentException;
 use mishagp\OCRmyPDF\Process;
 use mishagp\OCRmyPDF\UnsuccessfulCommandException;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use function PHPUnit\Framework\assertEquals;
+use function PHPUnit\Framework\assertFalse;
 
+#[CoversClass(Process::class)]
 class ProcessTest extends TestCase
 {
     public function testCheckProcessCreationFailed(): void
@@ -26,7 +30,7 @@ class ProcessTest extends TestCase
         $reflectedProcessStdin->setAccessible(true);
         $reflectedProcessStdin->setValue($process, null);
 
-        $this->assertFalse($process->write("test", 0));
+        assertFalse($process->write("test", 0));
     }
 
     public function testWaitWithNullStdin(): void
@@ -39,7 +43,7 @@ class ProcessTest extends TestCase
         $reflectedProcessStdin->setAccessible(true);
         $reflectedProcessStdin->setValue($process, null);
 
-        $this->assertEquals([
+        assertEquals([
             "out" => "",
             "err" => ""
         ], $process->wait());


### PR DESCRIPTION
1. **Dependency Updates**: The versions of `PHPUnit` and `PHPStan` were updated to their latest major versions (`PHPUnit 11` and `PHPStan 2.0`), along with the integration of `phpstan/phpstan-strict-rules` to enforce stricter static analysis.
2. **Static Analysis Level Increase**: Increased `PHPStan`'s analysis level to the highest (level 10) for stricter code scrutiny.
3. **Code Refinements**: Added stricter type checks and improved conditions in the source code, replacing loose comparisons (`==`) with strict ones (`===`) and ensuring better handling of nullable values.
4. **Test Improvements**: Simplified assertions in tests and added attributes like `#[CoversClass]` for better PHPUnit coverage reporting. Additionally, common test behaviors were extracted into a helper class.
5. **Configuration Enhancements**: Improved PHPUnit configuration to include stricter error handling, better cache management, and streamlined test definitions. New `.idea` and cache-related files were added to `.gitignore` to reduce clutter.